### PR TITLE
change location of astro css include

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css';
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400&family=Roboto:wght@200;300;400;500;600;800&display=swap');
 
 * {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 
 import App from './app';
 import './index.css';
+import '@astrouxds/astro-web-components/dist/astro-web-components/astro-web-components.css';
 
 const root = document.getElementById('root') as HTMLElement;
 createRoot(root).render(


### PR DESCRIPTION
So Mark and I were looking through this the other day while trying to suss out why the stylesheets are not yet correct. This doesn't solve that but while we were trying to test using some local symlinks we realized that the css include for astro web components should be in index.js instead of index.css Otherwise if you symlink it throws and error because react doesn't like it when you import from other folders.

I've been using your app to test react stuff so I figured I'd request the small change. :)